### PR TITLE
Prompt for auxiliary file at macro start

### DIFF
--- a/main.cls
+++ b/main.cls
@@ -13,6 +13,11 @@ Sub AggregateData_UserSelected_Ver4()
     Dim selectedWorkbook As Workbook
     Dim selectedFileName As Variant
     Dim colIndex As Long
+    Dim infoFileName As Variant
+    Dim infoWorkbook As Workbook
+    Dim infoWs As Worksheet
+    Dim infoLastRow As Long
+    Dim infoDict As Object
 
     ' 処理するブックを選択
     selectedFileName = Application.GetOpenFilename("Excel Files (*.xls; *.xlsx), *.xls; *.xlsx", , "Select the workbook cells to be processed")
@@ -28,6 +33,25 @@ Sub AggregateData_UserSelected_Ver4()
     If ws Is Nothing Then
         MsgBox "No sheet selected. Exiting.", vbExclamation
         Exit Sub
+    End If
+
+    ' 追加情報ファイルを冒頭で選択
+    infoFileName = Application.GetOpenFilename("Excel Files (*.xls; *.xlsx), *.xls; *.xlsx", , _
+                    "Select the workbook containing additional information")
+    If infoFileName <> False Then
+        Set infoWorkbook = Workbooks.Open(infoFileName)
+        Set infoWs = infoWorkbook.Sheets(1)
+        infoLastRow = infoWs.Cells(infoWs.Rows.Count, "A").End(xlUp).Row
+
+        Set infoDict = CreateObject("Scripting.Dictionary")
+        For Each cell In infoWs.Range("A2:A" & infoLastRow)
+            key = CStr(cell.Value)
+            If Not infoDict.Exists(key) Then
+                infoDict.Add key, infoWs.Cells(cell.Row, "T").Value
+            End If
+        Next cell
+
+        infoWorkbook.Close SaveChanges:=False
     End If
     
 Application.ScreenUpdating = False
@@ -119,42 +143,18 @@ Application.EnableEvents = False
     newWs.Range("G1").Value = "Qty.BOM Data"
     newWs.Range("G1").Interior.Color = RGB(255, 165, 0) ' オレンジ
 
-    ' 4b. 追加情報列の挿入 (I列) と別ファイルからの値の取得
+    ' 4b. 追加情報列の挿入 (I列) と冒頭で選択したファイルからの値の取得
     newWs.Columns("I").Insert
     newWs.Range("I1").Value = "Note"
     newWs.Range("I1").Interior.Color = RGB(0, 255, 0) ' 緑
 
-    ' 追加で読み込むブックを選択し、A列をキーとしてT列の値を取得
-    Dim infoFileName As Variant
-    Dim infoWorkbook As Workbook
-    Dim infoWs As Worksheet
-    Dim infoLastRow As Long
-    Dim infoDict As Object
-
-    infoFileName = Application.GetOpenFilename("Excel Files (*.xls; *.xlsx), *.xls; *.xlsx", , _
-                    "Select the workbook containing additional information")
-
-    If infoFileName <> False Then
-        Set infoWorkbook = Workbooks.Open(infoFileName)
-        Set infoWs = infoWorkbook.Sheets(1)
-        infoLastRow = infoWs.Cells(infoWs.Rows.Count, "A").End(xlUp).Row
-
-        Set infoDict = CreateObject("Scripting.Dictionary")
-        For Each cell In infoWs.Range("A2:A" & infoLastRow)
-            key = CStr(cell.Value)
-            If Not infoDict.Exists(key) Then
-                infoDict.Add key, infoWs.Cells(cell.Row, "T").Value
-            End If
-        Next cell
-
+    If Not infoDict Is Nothing Then
         For rowIndex = 2 To outputRow - 1
             key = CStr(newWs.Cells(rowIndex, "A").Value)
             If infoDict.Exists(key) Then
                 newWs.Cells(rowIndex, "I").Value = infoDict(key)
             End If
         Next rowIndex
-
-        infoWorkbook.Close SaveChanges:=False
     End If
 
     ' 5. オートフィルターとソート


### PR DESCRIPTION
## Summary
- Ask for auxiliary information workbook at the start of the macro.
- Populate "Note" column using data from the preloaded workbook.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c788b10070832b9b5c46e63194401c